### PR TITLE
Connect: add OpenReader function

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -46,9 +46,14 @@ func (conn *connect) Open(filePath string) error {
 	if err != nil {
 		return err
 	}
-	conn.zipReader = &zipReaderCloser.Reader
+	return conn.OpenReader(&zipReaderCloser.Reader)
+}
+
+// Open a excel file from a zipReader
+func (conn *connect) OpenReader(reader *zip.Reader) error {
+	conn.zipReader = reader
 	// prepare for files
-	err = conn.init()
+	err := conn.init()
 	if err != nil {
 		if conn.zipReaderCloser != nil {
 			conn.zipReaderCloser.Close()

--- a/types.go
+++ b/types.go
@@ -1,5 +1,7 @@
 package excel
 
+import "archive/zip"
+
 // Config of connecter
 type Config struct {
 	// sheet: if sheet is string, will use sheet as sheet name.
@@ -37,6 +39,10 @@ type Reader interface {
 type Connecter interface {
 	// Open a file of excel
 	Open(filePath string) error
+
+	// Open a zip.Reader of a file of excel
+	OpenReader(reader *zip.Reader) error
+
 	// Open a binary of excel
 	OpenBinary(xlsxData []byte) error
 


### PR DESCRIPTION
Add option to open by passing a *zip.Reader object as well to support situations when we have a stream but not necessarily an actual file.