### PR TITLE
Expose sheet size and input offset

### DIFF
--- a/advance_test.go
+++ b/advance_test.go
@@ -99,6 +99,11 @@ func TestRead(t *testing.T) {
 	}
 	defer rd.Close()
 
+	expectedSheetSize := uint64(2036)
+	if rd.GetSheetSize() != expectedSheetSize {
+		t.Errorf("unexpect sheet size: %d", rd.GetSheetSize())
+	}
+
 	idx := 0
 	for rd.Next() {
 		var a Advance
@@ -113,6 +118,10 @@ func TestRead(t *testing.T) {
 		}
 
 		idx++
+	}
+
+	if rd.InputOffset() != int64(expectedSheetSize) {
+		t.Errorf("unexpect input offset: %d", rd.InputOffset())
 	}
 }
 

--- a/connect.go
+++ b/connect.go
@@ -137,7 +137,7 @@ func (conn *connect) NewReaderByConfig(config *Config) (Reader, error) {
 	if err != nil {
 		return nil, err
 	}
-	reader, err := newReader(conn, rc, config.TitleRowIndex, config.Skip)
+	reader, err := newReader(conn, rc, config.TitleRowIndex, config.Skip, sheet)
 	return reader, err
 }
 

--- a/read.go
+++ b/read.go
@@ -18,6 +18,7 @@ type read struct {
 	decoderReadCloseer io.ReadCloser
 	title              *titleRow
 	schameMap          map[reflect.Type]*schema
+	worksheetName      string
 }
 
 // Move the cursor to next row's start.
@@ -63,6 +64,14 @@ func (rd *read) Read(i interface{}) error {
 	default:
 		return fmt.Errorf("%T should be pointer to struct or map[string]string", i)
 	}
+}
+
+func (rd *read) InputOffset() int64 {
+	return rd.decoder.InputOffset()
+}
+
+func (rd *read) GetSheetSize() uint64 {
+	return rd.connecter.worksheetNameFileMap[rd.worksheetName].UncompressedSize64
 }
 
 func (rd *read) Close() error {
@@ -466,8 +475,8 @@ func (rd *read) getSchame(t reflect.Type) *schema {
 	return s
 }
 
-func newReader(cn *connect, workSheetFileReader io.ReadCloser, titleRowIndex, skip int) (Reader, error) {
-	rd, err := newBaseReaderByWorkSheetFile(cn, workSheetFileReader)
+func newReader(cn *connect, workSheetFileReader io.ReadCloser, titleRowIndex, skip int, sheetName string) (Reader, error) {
+	rd, err := newBaseReaderByWorkSheetFile(cn, workSheetFileReader, sheetName)
 	if err != nil {
 		return nil, err
 	}
@@ -494,7 +503,7 @@ func newReader(cn *connect, workSheetFileReader io.ReadCloser, titleRowIndex, sk
 }
 
 // Make a base reader to sheet
-func newBaseReaderByWorkSheetFile(cn *connect, rc io.ReadCloser) (*read, error) {
+func newBaseReaderByWorkSheetFile(cn *connect, rc io.ReadCloser, sheetName string) (*read, error) {
 	decoder := xml.NewDecoder(rc)
 	// step into root [xml.StartElement] token
 	func(decoder *xml.Decoder) {
@@ -536,6 +545,7 @@ func newBaseReaderByWorkSheetFile(cn *connect, rc io.ReadCloser) (*read, error) 
 		connecter:          cn,
 		decoder:            decoder,
 		decoderReadCloseer: rc,
+		worksheetName:      sheetName,
 	}
 
 	return rd, nil

--- a/types.go
+++ b/types.go
@@ -31,6 +31,10 @@ type Reader interface {
 	ReadAll(container interface{}) error
 	// Read next rows
 	Next() bool
+	// Returns the sheet reader's byte offset within the file
+	InputOffset() int64
+	// Get the sheet size
+	GetSheetSize() uint64
 	// Close the reader
 	Close() error
 }


### PR DESCRIPTION
This PR adds two functions: `GetSheetSize` and `InputOffset`. Since this library is very useful for iteratively reading xlsx files, these functions can be very useful in terms of assessing how much of the file we want to read and how much of it we've read already. Without these functions one would have to use reflection to get this type of information, so I think it's really worthwhile to add :)